### PR TITLE
Check fqn prefix for dependencies, not direct match.

### DIFF
--- a/src/deps.d
+++ b/src/deps.d
@@ -85,3 +85,24 @@ unittest
 
     reader(only(line)).should.equal(only(tuple(client, supplier)));
 }
+
+bool crossesPrefix(const Dependency dependency, const string prefix)
+{
+    import util : fqnPrefixed, fqnStartsWith;
+
+    return dependency.client.fqnPrefixed(prefix) && !dependency.supplier.fqnStartsWith(prefix)
+        || dependency.supplier.fqnPrefixed(prefix) && !dependency.client.fqnStartsWith(prefix);
+}
+
+@("dependencies crossing a prefix path")
+unittest
+{
+    assert(Dependency("a.x", "b.y").crossesPrefix("a"));
+    assert(Dependency("a.x", "b.y").crossesPrefix("b"));
+    assert(Dependency("a.x", "b").crossesPrefix("a"));
+    assert(!Dependency("a", "a.y").crossesPrefix("a"));
+    assert(!Dependency("a.x", "a").crossesPrefix("a"));
+    assert(!Dependency("a.x", "a.y").crossesPrefix("a"));
+    assert(!Dependency("a", "a.b.y").crossesPrefix("a"));
+    assert(Dependency("a", "a.b.y").crossesPrefix("a.b"));
+}

--- a/src/main.d
+++ b/src/main.d
@@ -6,13 +6,14 @@
 import core.stdc.stdlib;
 import deps;
 import graph;
-import settings : packages, readSettings = read;
+import settings : readSettings = read;
 import std.algorithm;
 import std.array;
 import std.regex;
 import std.stdio;
 import std.typecons;
 import uml;
+import util : fqnStartsWith, packages;
 
 void main(string[] args)
 {
@@ -78,7 +79,7 @@ void main(string[] args)
         {
             import uml : read;
 
-            uint count = 0;
+            bool errored = false;
             Dependency[] targetDependencies = null;
 
             foreach (targetFile; targetFiles)
@@ -99,13 +100,14 @@ void main(string[] args)
                     if (dependency.client.empty || dependency.supplier.empty || dependency.client == dependency.supplier)
                         continue;
                 }
-                if (!targetDependencies.canFind(dependency))
+                if (!targetDependencies.canFind!(a =>
+                    dependency.client.fqnStartsWith(a.client) && dependency.supplier.fqnStartsWith(a.supplier)))
                 {
                     stderr.writefln("error: unintended dependency %s -> %s", client, supplier);
-                    ++count;
+                    errored = true;
                 }
             }
-            if (count > 0)
+            if (errored)
                 exit(EXIT_FAILURE);
         }
         if (dot || targetFiles.empty)

--- a/src/settings.d
+++ b/src/settings.d
@@ -87,19 +87,3 @@ unittest
         detail.should.be(true);
     }
 }
-
-string packages(string fullyQualifiedName)
-{
-    import std.range : dropBackOne;
-
-    return fullyQualifiedName.split('.')
-        .dropBackOne
-        .join('.');
-}
-
-@("split packages from a fully-qualified module name")
-unittest
-{
-    packages("bar.baz.foo").should.equal("bar.baz");
-    packages("foo").should.be.empty;
-}

--- a/src/util.d
+++ b/src/util.d
@@ -35,3 +35,16 @@ unittest
     "foo".fqnStartsWith("fo").should.be(false);
     "foo.bar.baz".fqnStartsWith("foo.ba").should.be(false);
 }
+
+bool fqnPrefixed(string haystack, string needle)
+{
+    return haystack.fqnStartsWith(needle) && haystack.length > needle.length;
+}
+
+@("fully-qualified module name prefixes other name")
+unittest
+{
+    "foo".fqnPrefixed("foo").should.be(false);
+    "foo".fqnPrefixed("bar").should.be(false);
+    "foo.bar".fqnPrefixed("foo").should.be(true);
+}

--- a/src/util.d
+++ b/src/util.d
@@ -1,0 +1,37 @@
+module util;
+
+import std.string;
+
+string packages(string fullyQualifiedName)
+{
+    import std.range : dropBackOne;
+
+    return fullyQualifiedName.split('.')
+        .dropBackOne
+        .join('.');
+}
+
+version (unittest) import dshould;
+
+@("split packages from a fully-qualified module name")
+unittest
+{
+    packages("bar.baz.foo").should.equal("bar.baz");
+    packages("foo").should.be.empty;
+}
+
+bool fqnStartsWith(string haystack, string needle)
+{
+    import std.algorithm : splitter;
+
+    return haystack.splitter(".").startsWith(needle.splitter("."));
+}
+
+@("fully-qualified module name starts with other name")
+unittest
+{
+    "foo".fqnStartsWith("foo").should.be(true);
+    "foo.bar.baz".fqnStartsWith("foo.bar").should.be(true);
+    "foo".fqnStartsWith("fo").should.be(false);
+    "foo.bar.baz".fqnStartsWith("foo.ba").should.be(false);
+}


### PR DESCRIPTION
Allows a declared dependency 'a -> b' to satisfy a module dependency 'a.x.y -> b.z'.