### PR TITLE
 Check fqn prefix for dependencies, not direct match.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -11,7 +11,7 @@ configuration "debug" {
     targetPath "build"
 }
 configuration "unittest" {
-    dependency "dshould" version="~>0"
+    dependency "dshould" version="~>1"
     dependency "unit-threaded" version="*"
     mainSourceFile "build/ut.d"
     excludedSourceFiles "src/main.d"

--- a/src/main.d
+++ b/src/main.d
@@ -6,13 +6,14 @@
 import core.stdc.stdlib;
 import deps;
 import graph;
-import settings : packages, readSettings = read;
+import settings : readSettings = read;
 import std.algorithm;
 import std.array;
 import std.regex;
 import std.stdio;
 import std.typecons;
 import uml;
+import util : fqnStartsWith, packages;
 
 void main(string[] args)
 {
@@ -78,7 +79,7 @@ void main(string[] args)
         {
             import uml : read;
 
-            uint count = 0;
+            bool errored = false;
             Dependency[] targetDependencies = null;
 
             foreach (targetFile; targetFiles)
@@ -99,13 +100,14 @@ void main(string[] args)
                     if (dependency.client.empty || dependency.supplier.empty || dependency.client == dependency.supplier)
                         continue;
                 }
-                if (!targetDependencies.canFind(dependency))
+                if (!targetDependencies.canFind!(a =>
+                    dependency.client.fqnStartsWith(a.client) && dependency.supplier.fqnStartsWith(a.supplier)))
                 {
                     stderr.writefln("error: unintended dependency %s -> %s", client, supplier);
-                    ++count;
+                    errored = true;
                 }
             }
-            if (count > 0)
+            if (errored)
                 exit(EXIT_FAILURE);
         }
         if (dot || targetFiles.empty)

--- a/src/settings.d
+++ b/src/settings.d
@@ -87,19 +87,3 @@ unittest
         detail.should.be(true);
     }
 }
-
-string packages(string fullyQualifiedName)
-{
-    import std.range : dropBackOne;
-
-    return fullyQualifiedName.split('.')
-        .dropBackOne
-        .join('.');
-}
-
-@("split packages from a fully-qualified module name")
-unittest
-{
-    packages("bar.baz.foo").should.equal("bar.baz");
-    packages("foo").should.be.empty;
-}

--- a/src/util.d
+++ b/src/util.d
@@ -1,0 +1,37 @@
+module util;
+
+import std.string;
+
+string packages(string fullyQualifiedName)
+{
+    import std.range : dropBackOne;
+
+    return fullyQualifiedName.split('.')
+        .dropBackOne
+        .join('.');
+}
+
+version (unittest) import dshould;
+
+@("split packages from a fully-qualified module name")
+unittest
+{
+    packages("bar.baz.foo").should.equal("bar.baz");
+    packages("foo").should.be.empty;
+}
+
+bool fqnStartsWith(string haystack, string needle)
+{
+    import std.algorithm : splitter;
+
+    return haystack.splitter(".").startsWith(needle.splitter("."));
+}
+
+@("fully-qualified module name starts with other name")
+unittest
+{
+    "foo".fqnStartsWith("foo").should.be(true);
+    "foo.bar.baz".fqnStartsWith("foo.bar").should.be(true);
+    "foo".fqnStartsWith("fo").should.be(false);
+    "foo.bar.baz".fqnStartsWith("foo.ba").should.be(false);
+}

--- a/src/util.d
+++ b/src/util.d
@@ -1,17 +1,16 @@
 module util;
 
+version(unittest) import dshould;
+import std.algorithm;
+import std.range;
 import std.string;
 
 string packages(string fullyQualifiedName)
 {
-    import std.range : dropBackOne;
-
     return fullyQualifiedName.split('.')
         .dropBackOne
         .join('.');
 }
-
-version (unittest) import dshould;
 
 @("split packages from a fully-qualified module name")
 unittest
@@ -22,8 +21,6 @@ unittest
 
 bool fqnStartsWith(string haystack, string needle)
 {
-    import std.algorithm : splitter;
-
     return haystack.splitter(".").startsWith(needle.splitter("."));
 }
 
@@ -34,4 +31,54 @@ unittest
     "foo.bar.baz".fqnStartsWith("foo.bar").should.be(true);
     "foo".fqnStartsWith("fo").should.be(false);
     "foo.bar.baz".fqnStartsWith("foo.ba").should.be(false);
+}
+
+/**
+ * This function takes two modules and returns the crossed package boundaries.
+ *
+ * Imagine a diagram of modules, where each module is recursively contained in
+ * successive packages. Now imagine an arrow drawn from the first to the second
+ * module. There may be some package boundaries that this arrow will necessarily have
+ * to cross to get to its destination. This function returns those boundaries.
+ */
+const(string)[] crossedPackageBoundaries(string from, string to)
+{
+    const fromPackages = from.successiveSplitPrefixes(".");
+    const toPackages = to.successiveSplitPrefixes(".");
+    const sharedPackages = fromPackages.commonPrefix(toPackages);
+    const numSharedPackages = count(sharedPackages);
+    const lastCommonPackage = sharedPackages.back; // at least ""
+    const fromUniquePackages = fromPackages.drop(numSharedPackages);
+    const toUniquePackages = toPackages.drop(numSharedPackages);
+    const traversalPath = chain(fromUniquePackages.retro, lastCommonPackage.only, toUniquePackages)
+        .dropOne.dropBackOne;
+
+    return traversalPath.filter!(a => !a.empty).array;
+}
+
+@("import crosses package boundaries")
+unittest
+{
+    crossedPackageBoundaries("a", "b").should.be.empty;
+    crossedPackageBoundaries("a", "b.y").should.be(["b"]);
+    crossedPackageBoundaries("a.x", "b").should.be(["a"]);
+    crossedPackageBoundaries("a.x", "b.y").should.be(["a", "b"]);
+    crossedPackageBoundaries("a.x", "a").should.be.empty;
+    crossedPackageBoundaries("a.x.y", "a").should.be(["a.x"]);
+}
+
+private string[] successiveSplitPrefixes(string haystack, string needle)
+{
+    auto parts = haystack.split(needle);
+
+    return (parts.length + 1).iota.map!(i => parts.take(i).join(needle)).array;
+}
+
+@("generate successive prefixes of a string split at a marker")
+unittest
+{
+    "".successiveSplitPrefixes(".").should.be([""]);
+    "a".successiveSplitPrefixes(".").should.be(["", "a"]);
+    "a.b".successiveSplitPrefixes(".").should.be(["", "a", "a.b"]);
+    "a.b.c".successiveSplitPrefixes(".").should.be(["", "a", "a.b", "a.b.c"]);
 }


### PR DESCRIPTION
Version of #5 that gathers the list of non-transitive dependencies in advance, as per conversation with @linkrope. I am not very sure if this is an improvement.