### PR TITLE
Check FQN prefix for dependencies to recursive modules

### DIFF
--- a/src/uml.d
+++ b/src/uml.d
@@ -1,5 +1,6 @@
 module uml;
 
+import deps : Dependency, Element;
 import graph;
 import std.algorithm;
 import std.range;
@@ -18,11 +19,10 @@ Dependency[] read(R)(R input)
 
 private void read(Input, Output)(Input input, auto ref Output output)
 {
-    import std.conv : to;
     import std.regex : matchFirst, regex;
 
     enum arrow = `(?P<arrow><?\.+(left|right|up|down|le?|ri?|up?|do?|\[.*?\])*\.*>?)`;
-    enum pattern = regex(`(?P<lhs>\w+(.\w+)*)\s*` ~ arrow ~ `\s*(?P<rhs>\w+(.\w+)*)`);
+    enum pattern = regex(`(?P<lhs>\w+(\.\w+)*(\.\*)?)\s*` ~ arrow ~ `\s*(?P<rhs>\w+(\.\w+)*(\.\*)?)`);
 
     foreach (line; input)
     {
@@ -30,13 +30,20 @@ private void read(Input, Output)(Input input, auto ref Output output)
 
         if (captures)
         {
-            const lhs = captures["lhs"].to!string;
-            const rhs = captures["rhs"].to!string;
+            enum recursiveMarker = ".all";
+
+            const string lhs = captures["lhs"].idup;
+            const lhsRecursive = lhs.endsWith(recursiveMarker) ? Yes.recursive : No.recursive;
+            const lhsElement = Element(lhsRecursive ? lhs.dropBack(recursiveMarker.length) : lhs, lhsRecursive);
+
+            const string rhs = captures["rhs"].idup;
+            const rhsRecursive = rhs.endsWith(recursiveMarker) ? Yes.recursive : No.recursive;
+            const rhsElement = Element(rhsRecursive ? rhs.dropBack(recursiveMarker.length) : rhs, rhsRecursive);
 
             if (captures["arrow"].endsWith(">"))
-                output.put(Dependency(lhs, rhs));
+                output.put(Dependency(lhsElement, rhsElement));
             if (captures["arrow"].startsWith("<"))
-                output.put(Dependency(rhs, lhs));
+                output.put(Dependency(rhsElement, lhsElement));
         }
     }
 }
@@ -44,11 +51,12 @@ private void read(Input, Output)(Input input, auto ref Output output)
 @("read Plant-UML dependencies")
 unittest
 {
-    read(only("a .> b")).should.be == [Dependency("a", "b")];
-    read(only("a <. b")).should.be == [Dependency("b", "a")];
-    read(only("a <.> b")).should.be == [Dependency("a", "b"), Dependency("b", "a")];
-    read(only("a.[#red]>b")).should.be == [Dependency("a", "b")];
-    read(only("a.[#red]le>b")).should.be == [Dependency("a", "b")];
+    read(only("a .> b")).should.be == [dependency("a", "b")];
+    read(only("a <. b")).should.be == [dependency("b", "a")];
+    read(only("a <.> b")).should.be == [dependency("a", "b"), dependency("b", "a")];
+    read(only("a.all .> b.all")).should.be == [Dependency(Element("a", Yes.recursive), Element("b", Yes.recursive))];
+    read(only("a.[#red]>b")).should.be == [dependency("a", "b")];
+    read(only("a.[#red]le>b")).should.be == [dependency("a", "b")];
 }
 
 void write(Output)(auto ref Output output, const Dependency[] dependencies)
@@ -69,7 +77,7 @@ unittest
     import std.string : outdent, stripLeft;
 
     auto output = appender!string;
-    const dependencies = [Dependency("a", "b")];
+    const dependencies = [dependency("a", "b")];
 
     output.write(dependencies);
 
@@ -92,7 +100,7 @@ unittest
     import std.string : outdent, stripLeft;
 
     auto output = appender!string;
-    const dependencies = [Dependency("a", "a.b"), Dependency("a.b", "a.c")];
+    const dependencies = [dependency("a", "a.b"), dependency("a.b", "a.c")];
 
     output.write(dependencies);
 
@@ -112,9 +120,37 @@ unittest
     output.data.should.be == outdent(expected).stripLeft;
 }
 
+@("use appropriate wildcard descriptions")
+unittest
+{
+    import std.array : appender;
+    import std.string : outdent, stripLeft;
+
+    auto output = appender!string;
+    const dependencies = [Dependency(Element("a", Yes.recursive), Element("b", Yes.recursive))];
+
+    output.write(dependencies);
+
+    const expected = `
+        @startuml
+        package a.* as a.all {}
+        package b.* as b.all {}
+
+        a.all ..> b.all
+        @enduml
+        `;
+
+    output.data.should.be == outdent(expected).stripLeft;
+}
+
+private alias dependency = (client, supplier) =>
+    Dependency(Element(client, No.recursive), Element(supplier, No.recursive));
+
 private struct Package
 {
     string[] path;
+
+    Flag!"recursive" recursive;
 
     Package[string] subpackages;
 
@@ -122,21 +158,21 @@ private struct Package
 
     void add(Dependency dependency)
     {
-        const clientPath = dependency.client.split('.');
-        const supplierPath = dependency.supplier.split('.');
+        const clientPath = dependency.client.name.split('.');
+        const supplierPath = dependency.supplier.name.split('.');
         const path = commonPrefix(clientPath.dropBackOne, supplierPath.dropBackOne);
 
-        addPackage(clientPath);
-        addPackage(supplierPath);
+        addPackage(clientPath, dependency.client.recursive);
+        addPackage(supplierPath, dependency.client.recursive);
         addDependency(path, dependency);
     }
 
-    void addPackage(const string[] path, size_t index = 0)
+    void addPackage(const string[] path, Flag!"recursive" recursive, size_t index = 0)
     {
         if (path[index] !in subpackages)
-            subpackages[path[index]] = Package(path[0 .. index + 1].dup);
+            subpackages[path[index]] = Package(path[0 .. index + 1].dup, recursive);
         if (index + 1 < path.length)
-            subpackages[path[index]].addPackage(path, index + 1);
+            subpackages[path[index]].addPackage(path, recursive, index + 1);
     }
 
     void addDependency(const string[] path, Dependency dependency)
@@ -160,7 +196,13 @@ private struct Package
         foreach (subpackage; subpackages.keys.sort.map!(key => subpackages[key]))
         {
             indent;
-            if (subpackage.path.length == 1)
+            if (subpackage.recursive)
+            {
+                assert(subpackage.subpackages.empty && subpackage.dependencies.empty,
+                    "recursive package must not contain subpackages");
+                output.formattedWrite!"package %s.* as %s.all {"(subpackage.path.back, subpackage.path.join('.'));
+            }
+            else if (subpackage.path.length == 1)
                 output.formattedWrite!"package %s {"(subpackage.path.join('.'));
             else
                 output.formattedWrite!"package %s as %s {"(subpackage.path.back, subpackage.path.join('.'));
@@ -178,7 +220,7 @@ private struct Package
         foreach (dependency; dependencies.sort)
         {
             indent;
-            output.formattedWrite!"%s ..> %s\n"(dependency.client, dependency.supplier);
+            output.formattedWrite!"%s ..> %s\n"(dependency.client.toPackage, dependency.supplier.toPackage);
         }
     }
 }

--- a/src/util.d
+++ b/src/util.d
@@ -1,0 +1,10 @@
+module util;
+
+import std.string;
+
+bool fqnStartsWith(string haystack, string needle)
+{
+    import std.algorithm : splitter;
+
+    return haystack.splitter(".").startsWith(needle.splitter("."));
+}


### PR DESCRIPTION
When a package ends with '.all', it is a "recursive package".
Dependencies to a recursive package implicitly include all subpackages.
Recursive packages must not contain explicit subpackages.
Recursive packages should be labeled as "foo.*"

Third try at this concept.