### PR TITLE
Add `--direct` mode that eschews DMD to parse imports manually.

### DIFF
--- a/src/direct.d
+++ b/src/direct.d
@@ -1,0 +1,71 @@
+module direct;
+
+import std.algorithm;
+import std.array;
+import std.exception;
+import std.file;
+import std.format;
+import std.path;
+import std.regex;
+import std.typecons;
+
+public auto extractImports(const string file, const string[] sources, const string[] includes)
+{
+    alias Module = Tuple!(string, "name", string, "path");
+    alias Dependency = Tuple!(Module, "client", Module, "supplier");
+
+    const source = file.readText;
+    auto moduleStatement = source.matchFirst(ctRegex!(`(^|[^\w])module\s*([\w\.]+);`));
+
+    enforce(!moduleStatement.empty, format!"%s: cannot find module statement"(file));
+
+    const moduleName = moduleStatement[2];
+
+    auto toModule(string name)
+    {
+        return Module(name, findModulePath(name, sources, includes));
+    }
+
+    // TODO filter out comments
+    auto importStatements = source.matchAll(ctRegex!(`[^\w]import\s+([\w\.]+)`));
+
+    return importStatements.map!(import_ => Dependency(Module(moduleName, file), toModule(import_[1]))).array;
+}
+
+private string findModulePath(const string name, const string[] sources, const string[] includes)
+{
+    const file = name.split(".").buildPath ~ ".d";
+
+    if (const path = findFilePath(file, sources, includes))
+    {
+        return path;
+    }
+
+    const packageFile = (name.split(".") ~ "package.d").buildPath;
+
+    if (const path = findFilePath(packageFile, sources, includes))
+    {
+        return path;
+    }
+    // fall back to relative path
+    return file;
+}
+
+private string findFilePath(const string partialPath, const string[] sources, const string[] includes)
+{
+    auto matchingSource = sources.find!(a => a.pathSplitter.endsWith(partialPath.pathSplitter));
+
+    if (!matchingSource.empty)
+    {
+        return matchingSource.front;
+    }
+
+    auto matchingIncludePath = includes.find!(a => a.chainPath(partialPath).exists);
+
+    if (!matchingIncludePath.empty)
+    {
+        return matchingIncludePath.front;
+    }
+
+    return null;
+}

--- a/src/settings.d
+++ b/src/settings.d
@@ -18,6 +18,7 @@ struct Settings
     string[] targetFiles = null;
     bool strict = false;
     string[] unrecognizedArgs;
+    bool readDirectly = false;
 }
 
 Settings read(string[] args)
@@ -44,6 +45,7 @@ in (!args.empty)
                 "dot", "Write dependency graph in the DOT language", &dot,
                 "check", "Check against the PlantUML target dependencies", &targetFiles,
                 "strict", "Do not use simplifying assumptions for the check", &strict,
+                "direct", "Do not invoke the compiler, but parse the given files directly", &readDirectly,
             );
         }
         catch (Exception exception)


### PR DESCRIPTION
Faster and uses less memory, but cannot handle comments, versions or mixins.